### PR TITLE
Add sensor history chart and async data fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,9 @@
         "react-native-reanimated": "^3.18.0",
         "react-native-safe-area-context": "^4.5.0",
         "react-native-screens": "^3.22.0",
-        "react-native-web": "~0.18.10"
+        "react-native-svg": "13.9.0",
+        "react-native-web": "~0.18.10",
+        "victory-native": "^36.9.1"
       },
       "devDependencies": {
         "babel-preset-expo": "9.4.0"
@@ -4285,6 +4287,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -6973,6 +7038,133 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-voronoi": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/d3-voronoi/-/d3-voronoi-1.1.4.tgz",
+      "integrity": "sha512-dArJ32hchFsrQ8uMiTBLq256MpnZjeuBtdHpaDlYuQyjU0CVzCJl/BVW+SkszaAeH95D/8gxqAhgx0ouAWAfRg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/dag-map": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
@@ -7186,6 +7378,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-4.0.1.tgz",
+      "integrity": "sha512-WNPWi1IRKZfCt/qIDMfERkDp93+iZEmOxN2yy4Jg+Xhv8SLk2UTqqbe1sfiipn0and9QrE914/ihdx82Y/Giag==",
+      "license": "ISC"
+    },
+    "node_modules/delaunay-find": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/delaunay-find/-/delaunay-find-0.0.6.tgz",
+      "integrity": "sha512-1+almjfrnR7ZamBk0q3Nhg6lqSe6Le4vL0WJDSMx4IDbQwTpUTXPjxC00lqLBT8MYsJpPCbI16sIkw9cPsbi7Q==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "^4.0.0"
       }
     },
     "node_modules/delayed-stream": {
@@ -9646,6 +9853,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -10655,6 +10871,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -14044,6 +14266,12 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
     "node_modules/react-freeze": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
@@ -14203,6 +14431,91 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-13.9.0.tgz",
+      "integrity": "sha512-Ey18POH0dA0ob/QiwCBVrxIiwflhYuw0P0hBlOHeY4J5cdbs8ngdKHeWC/Kt9+ryP6fNoEQ1PUgPYw2Bs/rp5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg/node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/react-native-svg/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/react-native-svg/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/react-native-svg/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/react-native-svg/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/react-native-web": {
@@ -16880,6 +17193,488 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/victory": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory/-/victory-36.9.2.tgz",
+      "integrity": "sha512-kgVgiSno4KpD0HxmUo5GzqWI4P/eILLOM6AmJfAlagCnOzrtYGsAw+N1YxOcYvTiKsh/zmWawxHlpw3TMenFDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "victory-area": "^36.9.2",
+        "victory-axis": "^36.9.2",
+        "victory-bar": "^36.9.2",
+        "victory-box-plot": "^36.9.2",
+        "victory-brush-container": "^36.9.2",
+        "victory-brush-line": "^36.9.2",
+        "victory-candlestick": "^36.9.2",
+        "victory-canvas": "^36.9.2",
+        "victory-chart": "^36.9.2",
+        "victory-core": "^36.9.2",
+        "victory-create-container": "^36.9.2",
+        "victory-cursor-container": "^36.9.2",
+        "victory-errorbar": "^36.9.2",
+        "victory-group": "^36.9.2",
+        "victory-histogram": "^36.9.2",
+        "victory-legend": "^36.9.2",
+        "victory-line": "^36.9.2",
+        "victory-pie": "^36.9.2",
+        "victory-polar-axis": "^36.9.2",
+        "victory-scatter": "^36.9.2",
+        "victory-selection-container": "^36.9.2",
+        "victory-shared-events": "^36.9.2",
+        "victory-stack": "^36.9.2",
+        "victory-tooltip": "^36.9.2",
+        "victory-voronoi": "^36.9.2",
+        "victory-voronoi-container": "^36.9.2",
+        "victory-zoom-container": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-area": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-36.9.2.tgz",
+      "integrity": "sha512-32aharvPf2RgdQB+/u1j3/ajYFNH/7ugLX9ZRpdd65gP6QEbtXL+58gS6CxvFw6gr/y8a0xMlkMKkpDVacXLpw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-axis": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-36.9.2.tgz",
+      "integrity": "sha512-4Odws+IAjprJtBg2b2ZCxEPgrQ6LgIOa22cFkGghzOSfTyNayN4M3AauNB44RZyn2O/hDiM1gdBkEg1g9YDevQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-bar": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-36.9.2.tgz",
+      "integrity": "sha512-R3LFoR91FzwWcnyGK2P8DHNVv9gsaWhl5pSr2KdeNtvLbZVEIvUkTeVN9RMBMzterSFPw0mbWhS1Asb3sV6PPw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-box-plot": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-36.9.2.tgz",
+      "integrity": "sha512-nUD45V/YHDkAKZyak7YDsz+Vk1F9N0ica3jWQe0AY0JqD9DleHa8RY/olSVws26kLyEj1I+fQqva6GodcLaIqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-container": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-container/-/victory-brush-container-36.9.2.tgz",
+      "integrity": "sha512-KcQjzFeo40tn52cJf1A02l5MqeR9GKkk3loDqM3T2hfi1PCyUrZXEUjGN5HNlLizDRvtcemaAHNAWlb70HbG/g==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-brush-line": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-brush-line/-/victory-brush-line-36.9.2.tgz",
+      "integrity": "sha512-/ncj8HEyl73fh8bhU4Iqe79DL62QP2rWWoogINxsGvndrhpFbL9tj7IPSEawi+riOh/CmohgI/ETu/V7QU9cJw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-candlestick": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-candlestick/-/victory-candlestick-36.9.2.tgz",
+      "integrity": "sha512-hbStzF61GHkkflJWFgLTZSR8SOm8siJn65rwApLJBIA283yWOlyPjdr/kIQtO/h5QkIiXIuLb7RyiUAJEnH9WA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-canvas": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-canvas/-/victory-canvas-36.9.2.tgz",
+      "integrity": "sha512-ImHJ7JQCpQ9aGCsh37EeVAmqJc7R0gl2CLM99gP9GfuJuZeoZ/GVfX6QFamfr19rYQOD2m9pVbecySBzdYI1zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-bar": "^36.9.2",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-chart": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-36.9.2.tgz",
+      "integrity": "sha512-dMNcS0BpqL3YiGvI4BSEmPR76FCksCgf3K4CSZ7C/MGyrElqB6wWwzk7afnlB1Qr71YIHXDmdwsPNAl/iEwTtA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-axis": "^36.9.2",
+        "victory-core": "^36.9.2",
+        "victory-polar-axis": "^36.9.2",
+        "victory-shared-events": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-core": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-36.9.2.tgz",
+      "integrity": "sha512-AzmMy+9MYMaaRmmZZovc/Po9urHne3R3oX7bbXeQdVuK/uMBrlPiv11gVJnuEH2SXLVyep43jlKgaBp8ef9stQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "react-fast-compare": "^3.2.0",
+        "victory-vendor": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-create-container": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-36.9.2.tgz",
+      "integrity": "sha512-uA0dh1R0YDzuXyE/7StZvq4qshet+WYceY7R1UR5mR/F9079xy+iQsa2Ca4h97/GtVZoLO6r1eKLWBt9TN+U7A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-brush-container": "^36.9.2",
+        "victory-core": "^36.9.2",
+        "victory-cursor-container": "^36.9.2",
+        "victory-selection-container": "^36.9.2",
+        "victory-voronoi-container": "^36.9.2",
+        "victory-zoom-container": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-cursor-container": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-36.9.2.tgz",
+      "integrity": "sha512-jidab4j3MaciF3fGX70jTj4H9rrLcY8o2LUrhJ67ZLvEFGGmnPtph+p8Fe97Umrag7E/DszjNxQZolpwlgUh3g==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-errorbar": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-errorbar/-/victory-errorbar-36.9.2.tgz",
+      "integrity": "sha512-i/WPMN6/7F55FpEpN9WcwiWwaFJ+2ymfTgfBDLkUD3XJ52HGen4BxUt1ouwDA3FXz9kLa/h6Wbp/fnRhX70row==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-group": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-36.9.2.tgz",
+      "integrity": "sha512-wBmpsjBTKva8mxHvHNY3b8RE58KtnpLLItEyyAHaYkmExwt3Uj8Cld3sF3vmeuijn2iR64NPKeMbgMbfZJzycw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.9.2",
+        "victory-shared-events": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-histogram": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-histogram/-/victory-histogram-36.9.2.tgz",
+      "integrity": "sha512-w0ipFwWZ533qyqduRacr5cf+H4PGAUTdWNyGvZbWyu4+GtYYjGdoOolfUcO1ee8VJ1kZodpG8Z7ud6I/GWIzjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-bar": "^36.9.2",
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-legend": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-36.9.2.tgz",
+      "integrity": "sha512-cucFJpv6fty+yXp5pElQFQnHBk1TqA4guGUMI+XF/wLlnuM4bhdAtASobRIIBkz0mHGBaCAAV4PzL9azPU/9dg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-line": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-36.9.2.tgz",
+      "integrity": "sha512-kmYFZUo0o2xC8cXRsmt/oUBRQSZJVT2IJnAkboUepypoj09e6CY5tRH4TSdfEDGkBk23xQkn7d4IFgl4kAGnSA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-native": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-native/-/victory-native-36.9.2.tgz",
+      "integrity": "sha512-BqOps0GfI8VAFF8/pDTy8BQLw9NxAitfHC2dr+Vmu9HYc3b3mmcBRzkYAkVRDFRVo//Xom2zy+Gmj1pKDtIGGw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "react-fast-compare": "^3.2.0",
+        "victory": "^36.9.2",
+        "victory-area": "^36.9.2",
+        "victory-axis": "^36.9.2",
+        "victory-bar": "^36.9.2",
+        "victory-box-plot": "^36.9.2",
+        "victory-brush-container": "^36.9.2",
+        "victory-brush-line": "^36.9.2",
+        "victory-candlestick": "^36.9.2",
+        "victory-chart": "^36.9.2",
+        "victory-core": "^36.9.2",
+        "victory-create-container": "^36.9.2",
+        "victory-cursor-container": "^36.9.2",
+        "victory-errorbar": "^36.9.2",
+        "victory-group": "^36.9.2",
+        "victory-histogram": "^36.9.2",
+        "victory-legend": "^36.9.2",
+        "victory-line": "^36.9.2",
+        "victory-pie": "^36.9.2",
+        "victory-polar-axis": "^36.9.2",
+        "victory-scatter": "^36.9.2",
+        "victory-selection-container": "^36.9.2",
+        "victory-shared-events": "^36.9.2",
+        "victory-stack": "^36.9.2",
+        "victory-tooltip": "^36.9.2",
+        "victory-voronoi": "^36.9.2",
+        "victory-voronoi-container": "^36.9.2",
+        "victory-zoom-container": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-pie": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-36.9.2.tgz",
+      "integrity": "sha512-i3zWezvy5wQEkhXKt4rS9ILGH7Vr9Q5eF9fKO4GMwDPBdYOTE3Dh2tVaSrfDC8g9zFIc0DKzOtVoJRTb+0AkPg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2",
+        "victory-vendor": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-polar-axis": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-polar-axis/-/victory-polar-axis-36.9.2.tgz",
+      "integrity": "sha512-HBR90FF4M56yf/atXjSmy3DMps1vSAaLXmdVXLM/A5g+0pUS7HO719r5x6dsR3I6Rm+8x6Kk8xJs0qgpnGQIEw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-scatter": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-36.9.2.tgz",
+      "integrity": "sha512-hK9AtbJQfaW05i8BH7Lf1HK7vWMAfQofj23039HEQJqTKbCL77YT+Q0LhZw1a1BRCpC/5aSg9EuqblhfIYw2wg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-selection-container": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-selection-container/-/victory-selection-container-36.9.2.tgz",
+      "integrity": "sha512-chboroEwqqVlMB60kveXM2WznJ33ZM00PWkFVCoJDzHHlYs7TCADxzhqet2S67SbZGSyvSprY2YztSxX8kZ+XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-shared-events": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-shared-events/-/victory-shared-events-36.9.2.tgz",
+      "integrity": "sha512-W/atiw3Or6MnpBuhluFv6007YrixIRh5NtiRvtFLGxNuQJLYjaSh6koRAih5xJer5Pj7YUx0tL9x67jTRcJ6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-stack": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-36.9.2.tgz",
+      "integrity": "sha512-imR6FniVlDFlBa/B3Est8kTryNhWj2ZNpivmVOebVDxkKcVlLaDg3LotCUOI7NzOhBQaro0UzeE9KmZV93JcYA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.9.2",
+        "victory-shared-events": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-tooltip": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-36.9.2.tgz",
+      "integrity": "sha512-76seo4TWD1WfZHJQH87IP3tlawv38DuwrUxpnTn8+uW6/CUex82poQiVevYdmJzhataS9jjyCWv3w7pOmLBCLg==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/victory-voronoi": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi/-/victory-voronoi-36.9.2.tgz",
+      "integrity": "sha512-50fq0UBTAFxxU+nabOIPE5P2v/2oAbGAX+Ckz6lu8LFwwig4J1DSz0/vQudqDGjzv3JNEdqTD4FIpyjbxLcxiA==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-voronoi": "^1.1.4",
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-voronoi-container": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-36.9.2.tgz",
+      "integrity": "sha512-NIVYqck9N4OQnEz9mgQ4wILsci3OBWWK7RLuITGHyoD7Ne/+WH1i0Pv2y9eIx+f55rc928FUTugPPhkHvXyH3A==",
+      "license": "MIT",
+      "dependencies": {
+        "delaunay-find": "0.0.6",
+        "lodash": "^4.17.19",
+        "react-fast-compare": "^3.2.0",
+        "victory-core": "^36.9.2",
+        "victory-tooltip": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
+      }
+    },
+    "node_modules/victory-zoom-container": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-36.9.2.tgz",
+      "integrity": "sha512-pXa2Ji6EX/pIarKT6Hcmmu2n7IG/x8Vs0D2eACQ/nbpvZa+DXWIxCRW4hcg2Va35fmXcDIEpGaX3/soXzZ+pbw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.19",
+        "victory-core": "^36.9.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0"
       }
     },
     "node_modules/vlq": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "react-native-reanimated": "^3.18.0",
     "react-native-safe-area-context": "^4.5.0",
     "react-native-screens": "^3.22.0",
-    "react-native-web": "~0.18.10"
+    "react-native-web": "~0.18.10",
+    "react-native-svg": "13.9.0",
+    "victory-native": "^36.9.1"
   },
   "devDependencies": {
     "babel-preset-expo": "9.4.0"

--- a/screens/SensorDetail.js
+++ b/screens/SensorDetail.js
@@ -1,38 +1,151 @@
-import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ActivityIndicator,
+  Button,
+  Alert,
+  ScrollView,
+} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import axios from 'axios';
+import { VictoryChart, VictoryLine, VictoryTheme } from 'victory-native';
 
 export default function SensorDetail({ route }) {
   const { sensor } = route.params;
 
   const [history, setHistory] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [currentReading, setCurrentReading] = useState(sensor);
+
+  const sensorId = sensor.sensorId;
+
+  const fetchHistory = useCallback(async () => {
+    try {
+      setLoading(true);
+      const storedBaseUrl = await AsyncStorage.getItem('apiUrl');
+
+      if (!storedBaseUrl) {
+        Alert.alert('Configuração necessária', 'Defina a URL da API nas configurações.');
+        setHistory([]);
+        return;
+      }
+
+      const baseUrl = storedBaseUrl.replace(/\/$/, '');
+      const response = await axios.get(`${baseUrl}/api/readings`, {
+        params: { sensorId },
+      });
+
+      const readings = Array.isArray(response.data)
+        ? response.data
+        : Array.isArray(response.data?.content)
+        ? response.data.content
+        : [];
+
+      const normalized = readings
+        .map((reading) => ({
+          ...reading,
+          readingValue: reading.readingValue ?? reading.value ?? 0,
+        }))
+        .sort((a, b) => new Date(a.timestamp) - new Date(b.timestamp));
+
+      setHistory(normalized);
+
+      if (normalized.length > 0) {
+        const latest = normalized[normalized.length - 1];
+        setCurrentReading((prev) => ({
+          ...prev,
+          readingValue: latest.readingValue,
+          timestamp: latest.timestamp,
+        }));
+      }
+    } catch (error) {
+      console.error('Erro ao carregar histórico do sensor:', error);
+      Alert.alert('Erro', 'Não foi possível carregar o histórico do sensor.');
+    } finally {
+      setLoading(false);
+    }
+  }, [sensorId]);
 
   useEffect(() => {
-    if (sensor.readingValue) {
-      const base = sensor.readingValue;
-      const valores = Array.from({ length: 5 }, (_, i) => base + (Math.random() * 4 - 2));
-      setHistory(valores);
+    setCurrentReading(sensor);
+    fetchHistory();
+  }, [sensor, fetchHistory]);
+
+  const handleRefresh = () => {
+    fetchHistory();
+  };
+
+  const handleRegisterReading = async () => {
+    try {
+      const storedBaseUrl = await AsyncStorage.getItem('apiUrl');
+      if (!storedBaseUrl) {
+        Alert.alert('Configuração necessária', 'Defina a URL da API nas configurações.');
+        return;
+      }
+
+      const baseUrl = storedBaseUrl.replace(/\/$/, '');
+      const newReading = {
+        sensorId,
+        value: Number((Math.random() * 100).toFixed(2)),
+        timestamp: new Date().toISOString(),
+      };
+
+      await axios.post(`${baseUrl}/api/readings`, newReading);
+      Alert.alert('Sucesso', 'Leitura registrada com sucesso!');
+      fetchHistory();
+    } catch (error) {
+      console.error('Erro ao registrar leitura:', error);
+      Alert.alert('Erro', 'Não foi possível registrar a leitura.');
     }
-  }, [sensor]);
+  };
+
+  const chartData = history.map((reading, index) => ({
+    x: index + 1,
+    y: Number(reading.readingValue ?? 0),
+  }));
 
   return (
-    <View style={styles.container}>
-      <Text style={styles.name}>{sensor.sensorId}</Text>
-      <Text style={styles.item}>Valor atual: {sensor.readingValue}</Text>
-      <Text style={styles.item}>Horário: {new Date(sensor.timestamp).toLocaleString()}</Text>
-      {history.map((valor, index) => (
-        <Text key={index} style={styles.item}>
-          {`Valor ${index + 1}: ${valor.toFixed(1)}`}
-        </Text>
-      ))}
-    </View>
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.name}>{sensorId}</Text>
+      <Text style={styles.item}>Valor atual: {currentReading?.readingValue ?? '-'}</Text>
+      <Text style={styles.item}>
+        Horário: {currentReading?.timestamp ? new Date(currentReading.timestamp).toLocaleString() : '-'}
+      </Text>
+
+      <View style={styles.buttonGroup}>
+        <View style={styles.buttonWrapper}>
+          <Button title="Atualizar" onPress={handleRefresh} color="#00838f" />
+        </View>
+        <View style={styles.buttonWrapper}>
+          <Button title="Registrar Leitura" onPress={handleRegisterReading} color="#00695c" />
+        </View>
+      </View>
+
+      {loading ? (
+        <ActivityIndicator size="large" color="#00838f" style={styles.loader} />
+      ) : history.length > 0 ? (
+        <VictoryChart theme={VictoryTheme.material} domainPadding={16}>
+          <VictoryLine
+            interpolation="monotoneX"
+            data={chartData}
+            style={{ data: { stroke: '#00838f', strokeWidth: 3 } }}
+          />
+        </VictoryChart>
+      ) : (
+        <Text style={styles.emptyText}>Nenhum histórico disponível.</Text>
+      )}
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
+    flexGrow: 1,
     padding: 16,
     backgroundColor: '#e0f7fa',
+    alignItems: 'stretch',
   },
   name: {
     fontSize: 22,
@@ -46,5 +159,22 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     color: '#004d40',
     textAlign: 'center',
-  }
+  },
+  buttonGroup: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginVertical: 16,
+    gap: 12,
+  },
+  buttonWrapper: {
+    flex: 1,
+  },
+  loader: {
+    marginTop: 32,
+  },
+  emptyText: {
+    textAlign: 'center',
+    color: '#004d40',
+    marginTop: 24,
+  },
 });


### PR DESCRIPTION
## Summary
- add victory-native charting dependencies for visualizing readings
- load sensor history from the API using stored base URL and expose refresh/register actions
- display sensor details with activity indicator and a line chart of historical values

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc933bb1a48320b633cc95524d6802